### PR TITLE
fixing segment_max edge cases and add more exception handling

### DIFF
--- a/.kokoro/github/ubuntu/gpu/build.sh
+++ b/.kokoro/github/ubuntu/gpu/build.sh
@@ -57,8 +57,6 @@ then
                --ignore keras/src/backend/jax/distribution_lib_test.py \
                --ignore keras/src/distribution/distribution_lib_test.py \
                --cov=keras
-
-   pytest keras/src/distribution/distribution_lib_test.py --cov=keras
 fi
 
 if [ "$KERAS_BACKEND" == "torch" ]

--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -199,7 +199,6 @@ from keras.src.ops.numpy import repeat
 from keras.src.ops.numpy import reshape
 from keras.src.ops.numpy import roll
 from keras.src.ops.numpy import round
-from keras.src.ops.numpy import searchsorted
 from keras.src.ops.numpy import select
 from keras.src.ops.numpy import sign
 from keras.src.ops.numpy import sin

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -199,7 +199,6 @@ from keras.src.ops.numpy import repeat
 from keras.src.ops.numpy import reshape
 from keras.src.ops.numpy import roll
 from keras.src.ops.numpy import round
-from keras.src.ops.numpy import searchsorted
 from keras.src.ops.numpy import select
 from keras.src.ops.numpy import sign
 from keras.src.ops.numpy import sin

--- a/keras/src/backend/common/keras_tensor.py
+++ b/keras/src/backend/common/keras_tensor.py
@@ -90,20 +90,6 @@ class KerasTensor:
 
         return ops.Squeeze(axis)(self)
 
-    def __int__(self):
-        raise ValueError(
-            "A KerasTensor is symbolic: it's a placeholder for a shape "
-            "an a dtype. It doesn't have any actual numerical value. "
-            "You cannot convert it to an int."
-        )
-
-    def __float__(self):
-        raise ValueError(
-            "A KerasTensor is symbolic: it's a placeholder for a shape "
-            "an a dtype. It doesn't have any actual numerical value. "
-            "You cannot convert it to a float."
-        )
-
     def __array__(self):
         raise ValueError(
             "A KerasTensor is symbolic: it's a placeholder for a shape "
@@ -335,12 +321,6 @@ class KerasTensor:
         from keras.src import ops
 
         return ops.GetItem().symbolic_call(self, key)
-
-    def __round__(self, ndigits=None):
-        from keras.src import ops
-
-        decimals = ndigits or 0
-        return ops.Round(decimals=decimals).symbolic_call(self)
 
 
 def any_symbolic_tensors(args=None, kwargs=None):

--- a/keras/src/backend/common/variables.py
+++ b/keras/src/backend/common/variables.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.backend import config
 from keras.src.backend.common import dtypes
@@ -340,22 +339,6 @@ class KerasVariable:
     def __getitem__(self, idx):
         return self.value.__getitem__(idx)
 
-    def __int__(self):
-        if self.ndim > 0:
-            raise TypeError(
-                "Only scalar arrays can be converted to Python scalars. "
-                f"Got: shape={self.shape}"
-            )
-        return int(self.value)
-
-    def __float__(self):
-        if self.ndim > 0:
-            raise TypeError(
-                "Only scalar arrays can be converted to Python scalars. "
-                f"Got: shape={self.shape}"
-            )
-        return float(self.value)
-
     def __array__(self, dtype=None):
         # We can't directly use self.value.__array__ here because of scalar.
         # Numpy require this method to return as array like object. In the case
@@ -379,92 +362,128 @@ class KerasVariable:
         return self.value.__invert__()
 
     def __eq__(self, other):
-        return backend.numpy.equal(self.value, other)
+        value = self.value
+        return value.__eq__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __ne__(self, other):
-        return backend.numpy.not_equal(self.value, other)
+        value = self.value
+        return value.__ne__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __lt__(self, other):
-        return backend.numpy.less(self.value, other)
+        value = self.value
+        return value.__lt__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __le__(self, other):
-        return backend.numpy.less_equal(self.value, other)
+        value = self.value
+        return value.__le__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __gt__(self, other):
-        return backend.numpy.greater(self.value, other)
+        value = self.value
+        return value.__gt__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __ge__(self, other):
-        return backend.numpy.greater_equal(self.value, other)
+        value = self.value
+        return value.__ge__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __add__(self, other):
-        return backend.numpy.add(self.value, other)
+        value = self.value
+        return value.__add__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __radd__(self, other):
-        return backend.numpy.add(other, self.value)
+        value = self.value
+        return value.__radd__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __sub__(self, other):
-        return backend.numpy.subtract(self.value, other)
+        value = self.value
+        return value.__sub__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __rsub__(self, other):
-        return backend.numpy.subtract(other, self.value)
+        value = self.value
+        return value.__rsub__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __mul__(self, other):
-        return backend.numpy.multiply(self.value, other)
+        value = self.value
+        return value.__mul__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __rmul__(self, other):
-        return backend.numpy.multiply(other, self.value)
+        value = self.value
+        return value.__rmul__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __truediv__(self, other):
-        return backend.numpy.true_divide(self.value, other)
+        value = self.value
+        return value.__truediv__(
+            self._convert_to_tensor(other, dtype=value.dtype)
+        )
 
     def __rtruediv__(self, other):
-        return backend.numpy.true_divide(other, self.value)
+        value = self.value
+        return value.__rtruediv__(
+            self._convert_to_tensor(other, dtype=value.dtype)
+        )
 
     def __floordiv__(self, other):
-        return backend.numpy.floor_divide(self.value, other)
+        value = self.value
+        return value.__floordiv__(
+            self._convert_to_tensor(other, dtype=value.dtype)
+        )
 
     def __rfloordiv__(self, other):
-        return backend.numpy.floor_divide(other, self.value)
+        value = self.value
+        return value.__rfloordiv__(
+            self._convert_to_tensor(other, dtype=value.dtype)
+        )
 
     def __mod__(self, other):
-        return backend.numpy.mod(self.value, other)
+        value = self.value
+        return value.__mod__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __rmod__(self, other):
-        return backend.numpy.mod(other, self.value)
+        value = self.value
+        return value.__rmod__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __pow__(self, other):
-        return backend.numpy.power(self.value, other)
+        value = self.value
+        return value.__pow__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __rpow__(self, other):
-        return backend.numpy.power(other, self.value)
+        value = self.value
+        return value.__rpow__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __matmul__(self, other):
-        return backend.numpy.matmul(self.value, other)
+        value = self.value
+        return value.__matmul__(
+            self._convert_to_tensor(other, dtype=value.dtype)
+        )
 
     def __rmatmul__(self, other):
-        return backend.numpy.matmul(other, self.value)
+        value = self.value
+        return value.__rmatmul__(
+            self._convert_to_tensor(other, dtype=value.dtype)
+        )
 
     def __and__(self, other):
-        return backend.numpy.logical_and(self.value, other)
+        value = self.value
+        return value.__and__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __rand__(self, other):
-        return backend.numpy.logical_and(other, self.value)
+        value = self.value
+        return value.__rand__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __or__(self, other):
-        return backend.numpy.logical_or(self.value, other)
+        value = self.value
+        return value.__or__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __ror__(self, other):
-        return backend.numpy.logical_or(other, self.value)
+        value = self.value
+        return value.__ror__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __xor__(self, other):
-        return backend.numpy.logical_xor(self.value, other)
+        value = self.value
+        return value.__xor__(self._convert_to_tensor(other, dtype=value.dtype))
 
     def __rxor__(self, other):
-        return backend.numpy.logical_xor(other, self.value)
-
-    def __round__(self, ndigits=None):
-        decimals = ndigits or 0
-        return backend.numpy.round(self.value, decimals=decimals)
+        value = self.value
+        return value.__rxor__(self._convert_to_tensor(other, dtype=value.dtype))
 
 
 def register_uninitialized_variable(variable):

--- a/keras/src/backend/common/variables_test.py
+++ b/keras/src/backend/common/variables_test.py
@@ -1,5 +1,3 @@
-import itertools
-
 import numpy as np
 import pytest
 from absl.testing import parameterized
@@ -13,7 +11,6 @@ from keras.src.backend.common.variables import shape_equal
 from keras.src.backend.common.variables import standardize_dtype
 from keras.src.backend.common.variables import standardize_shape
 from keras.src.testing import test_case
-from keras.src.testing.test_utils import named_product
 
 
 class VariableInitializationTest(test_case.TestCase):
@@ -229,12 +226,6 @@ class VariablePropertiesTest(test_case.TestCase, parameterized.TestCase):
         ):
             standardize_shape([3, 4, -5])
 
-    def test_shape_equal_length_mismatch(self):
-        """Test mismatch in lengths of shapes."""
-        self.assertFalse(shape_equal((3, 2), (3, 2, 4)))
-        self.assertFalse(shape_equal((), (3,)))
-        self.assertFalse(shape_equal((3, 2, 4, 5), (3, 2, 4)))
-
     def test_autocast_scope_with_non_float_dtype(self):
         """Tests autocast scope with non-float dtype."""
         with self.assertRaisesRegex(
@@ -379,16 +370,16 @@ class VariableDtypeShapeNdimRepr(test_case.TestCase):
         self.assertAllClose(v.__array__(), np.array([1, 2, 3]))
 
 
-class VariableOpsCorrentnessTest(test_case.TestCase):
+class VariableOperationsTest(test_case.TestCase):
     """Tests for operations on KerasVariable."""
 
-    def test_int(self):
-        v = backend.Variable(initializer=np.array(-1.1))
-        self.assertAllClose(int(v), np.array(-1))
-
-    def test_float(self):
-        v = backend.Variable(initializer=np.array(-1.1))
-        self.assertAllClose(float(v), np.array(-1.1))
+    def test_variable_as_boolean(self):
+        """Test converting a variable to boolean."""
+        v = backend.Variable(initializer=np.ones((2, 2)))
+        with self.assertRaisesRegex(
+            TypeError, "A Keras Variable cannot be used as a boolean."
+        ):
+            bool(v)
 
     def test__neg__(self):
         """Test negating a variable."""
@@ -618,353 +609,50 @@ class VariableOpsCorrentnessTest(test_case.TestCase):
         result = v2**v1
         self.assertAllClose(result, np.array([4, 25, 216]))
 
-    def test_round(self):
-        v = backend.Variable(initializer=np.array([1.1, 2.2, 3.3]))
-        self.assertAllClose(round(v), np.array([1, 2, 3]))
 
+class VariableBinaryOperationsTest(test_case.TestCase):
+    """Tests for binary operations on KerasVariable."""
 
-class VariableOpsBehaviorTest(test_case.TestCase):
-    def test_invalid_bool(self):
+    def test_variable_bool(self):
         """Test converting a variable to boolean."""
-        v = backend.Variable(initializer=np.ones((2, 2)))
-        with self.assertRaisesRegex(
-            TypeError, "A Keras Variable cannot be used as a boolean."
-        ):
+        v = backend.Variable(initializer=np.array([1, 2, 3]))
+        with self.assertRaises(TypeError):
             bool(v)
 
-    def test_invalid_int(self):
-        v = backend.Variable(initializer=np.ones((2, 2)))
+    def test_variable_neg(self):
+        """Test negating a variable."""
+        v = backend.Variable(initializer=np.array([-1, 2]))
+        neg_v = -v
+        self.assertAllClose(neg_v, np.array([1, -2]))
+
+    def test_variable_abs(self):
+        """Test absolute value of a variable."""
+        v = backend.Variable(initializer=np.array([-1, 2]))
+        abs_v = abs(v)
+        self.assertAllClose(abs_v, np.array([1, 2]))
+
+    def test_invalid_dtype(self):
+        """Test invalid dtype standardization."""
+        invalid_dtype = "invalid_dtype"
         with self.assertRaisesRegex(
-            TypeError, "Only scalar arrays can be converted to Python scalars."
+            ValueError, f"Invalid dtype: {invalid_dtype}"
         ):
-            int(v)
+            standardize_dtype(invalid_dtype)
 
-    def test_invalid_float(self):
-        v = backend.Variable(initializer=np.ones((2, 2)))
+    def test_negative_shape_entry(self):
+        """Test negative shape entry."""
+        shape = (3, -1, 5)
         with self.assertRaisesRegex(
-            TypeError, "Only scalar arrays can be converted to Python scalars."
+            ValueError,
+            "Negative dimensions are not allowed",
         ):
-            float(v)
+            standardize_shape(shape)
 
-
-class VariableOpsDTypeTest(test_case.TestCase, parameterized.TestCase):
-    """Test the dtype to verify that the behavior matches JAX."""
-
-    # TODO: Using uint64 will lead to weak type promotion (`float`),
-    # resulting in different behavior between JAX and Keras. Currently, we
-    # are skipping the test for uint64
-    ALL_DTYPES = [
-        x for x in dtypes.ALLOWED_DTYPES if x not in ["string", "uint64"]
-    ] + [None]
-    INT_DTYPES = [x for x in dtypes.INT_TYPES if x != "uint64"]
-    FLOAT_DTYPES = dtypes.FLOAT_TYPES
-
-    if backend.backend() == "torch":
-        # TODO: torch doesn't support uint16, uint32 and uint64
-        ALL_DTYPES = [
-            x for x in ALL_DTYPES if x not in ["uint16", "uint32", "uint64"]
-        ]
-        INT_DTYPES = [
-            x for x in INT_DTYPES if x not in ["uint16", "uint32", "uint64"]
-        ]
-    # Remove float8 dtypes for the following tests
-    ALL_DTYPES = [x for x in ALL_DTYPES if x not in dtypes.FLOAT8_TYPES]
-
-    def setUp(self):
-        from jax.experimental import enable_x64
-
-        self.jax_enable_x64 = enable_x64()
-        self.jax_enable_x64.__enter__()
-        return super().setUp()
-
-    def tearDown(self) -> None:
-        self.jax_enable_x64.__exit__(None, None, None)
-        return super().tearDown()
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_eq(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.equal(x1_jax, x2_jax).dtype)
-
-        self.assertDType(x1 == x2, expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_ne(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.not_equal(x1_jax, x2_jax).dtype)
-
-        self.assertDType(x1 != x2, expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_lt(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.less(x1_jax, x2_jax).dtype)
-
-        self.assertDType(x1 < x2, expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_le(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.less_equal(x1_jax, x2_jax).dtype)
-
-        self.assertDType(x1 <= x2, expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_gt(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.greater(x1_jax, x2_jax).dtype)
-
-        self.assertDType(x1 > x2, expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_ge(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(
-            jnp.greater_equal(x1_jax, x2_jax).dtype
-        )
-
-        self.assertDType(x1 >= x2, expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_add(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.add(x1_jax, x2_jax).dtype)
-
-        self.assertDType(x1 + x2, expected_dtype)
-        self.assertDType(x1.__radd__(x2), expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_sub(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.add(x1_jax, x2_jax).dtype)
-
-        self.assertDType(x1 - x2, expected_dtype)
-        self.assertDType(x1.__rsub__(x2), expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_mul(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.add(x1_jax, x2_jax).dtype)
-
-        self.assertDType(x1 * x2, expected_dtype)
-        self.assertDType(x1.__rmul__(x2), expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_truediv(self, dtypes):
-        import jax.experimental
-        import jax.numpy as jnp
-
-        # We have to disable x64 for jax since jnp.true_divide doesn't respect
-        # JAX_DEFAULT_DTYPE_BITS=32 in `./conftest.py`. We also need to downcast
-        # the expected dtype from 64 bit to 32 bit when using jax backend.
-        with jax.experimental.disable_x64():
-            dtype1, dtype2 = dtypes
-            x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-            x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-            x1_jax = jnp.ones((1,), dtype=dtype1)
-            x2_jax = jnp.ones((1,), dtype=dtype2)
-            expected_dtype = standardize_dtype(
-                jnp.true_divide(x1_jax, x2_jax).dtype
-            )
-            if "float64" in (dtype1, dtype2):
-                expected_dtype = "float64"
-            if backend.backend() == "jax":
-                expected_dtype = expected_dtype.replace("64", "32")
-
-            self.assertDType(x1 / x2, expected_dtype)
-            self.assertDType(x1.__rtruediv__(x2), expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_floordiv(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(
-            jnp.floor_divide(x1_jax, x2_jax).dtype
-        )
-
-        self.assertDType(x1 // x2, expected_dtype)
-        self.assertDType(x1.__rfloordiv__(x2), expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_mod(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.mod(x1_jax, x2_jax).dtype)
-
-        self.assertDType(x1 % x2, expected_dtype)
-        self.assertDType(x1.__rmod__(x2), expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_pow(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.power(x1_jax, x2_jax).dtype)
-
-        self.assertDType(x1**x2, expected_dtype)
-        self.assertDType(x1.__rpow__(x2), expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_matmul(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.matmul(x1_jax, x2_jax).dtype)
-
-        self.assertDType(x1 @ x2, expected_dtype)
-        self.assertDType(x1.__rmatmul__(x2), expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_and(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(
-            jnp.logical_and(x1_jax, x2_jax).dtype
-        )
-
-        self.assertDType(x1 & x2, expected_dtype)
-        self.assertDType(x1.__rand__(x2), expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_or(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(jnp.logical_or(x1_jax, x2_jax).dtype)
-
-        self.assertDType(x1 | x2, expected_dtype)
-        self.assertDType(x1.__ror__(x2), expected_dtype)
-
-    @parameterized.named_parameters(
-        named_product(dtypes=itertools.combinations(ALL_DTYPES, 2))
-    )
-    def test_xor(self, dtypes):
-        import jax.numpy as jnp
-
-        dtype1, dtype2 = dtypes
-        x1 = backend.Variable(np.ones((1,)), dtype=dtype1, trainable=False)
-        x2 = backend.Variable(np.ones((1,)), dtype=dtype2, trainable=False)
-        x1_jax = jnp.ones((1,), dtype=dtype1)
-        x2_jax = jnp.ones((1,), dtype=dtype2)
-        expected_dtype = standardize_dtype(
-            jnp.logical_xor(x1_jax, x2_jax).dtype
-        )
-
-        self.assertDType(x1 ^ x2, expected_dtype)
-        self.assertDType(x1.__rxor__(x2), expected_dtype)
+    def test_shape_equal_length_mismatch(self):
+        """Test mismatch in lengths of shapes."""
+        self.assertFalse(shape_equal((3, 2), (3, 2, 4)))
+        self.assertFalse(shape_equal((), (3,)))
+        self.assertFalse(shape_equal((3, 2, 4, 5), (3, 2, 4)))
 
 
 @pytest.mark.skipif(

--- a/keras/src/backend/exports.py
+++ b/keras/src/backend/exports.py
@@ -1,6 +1,5 @@
 from keras.src import backend
 from keras.src.api_export import keras_export
-from keras.src.backend.common import KerasVariable
 
 if backend.backend() == "tensorflow":
     BackendVariable = backend.tensorflow.core.Variable
@@ -21,7 +20,7 @@ else:
 
 
 @keras_export("keras.Variable")
-class Variable(BackendVariable, KerasVariable):
+class Variable(BackendVariable):
     pass
 
 

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -878,17 +878,6 @@ def roll(x, shift, axis=None):
     return jnp.roll(x, shift, axis=axis)
 
 
-def searchsorted(sorted_sequence, values, side="left"):
-    if ndim(sorted_sequence) != 1:
-        raise ValueError(
-            "`searchsorted` only supports 1-D sorted sequences. "
-            "You can use `keras.ops.vectorized_map` "
-            "to extend it to N-D sequences. Received: "
-            f"sorted_sequence.shape={sorted_sequence.shape}"
-        )
-    return jnp.searchsorted(sorted_sequence, values, side=side)
-
-
 @sparse.elementwise_unary(linear=False)
 def sign(x):
     x = convert_to_tensor(x)

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -789,20 +789,6 @@ def roll(x, shift, axis=None):
     return np.roll(x, shift, axis=axis)
 
 
-def searchsorted(sorted_sequence, values, side="left"):
-    if ndim(sorted_sequence) != 1:
-        raise ValueError(
-            "`searchsorted` only supports 1-D sorted sequences. "
-            "You can use `keras.ops.vectorized_map` "
-            "to extend it to N-D sequences. Received: "
-            f"sorted_sequence.shape={sorted_sequence.shape}"
-        )
-    out_type = (
-        "int32" if len(sorted_sequence) <= np.iinfo(np.int32).max else "int64"
-    )
-    return np.searchsorted(sorted_sequence, values, side=side).astype(out_type)
-
-
 def sign(x):
     return np.sign(x)
 

--- a/keras/src/backend/tensorflow/math.py
+++ b/keras/src/backend/tensorflow/math.py
@@ -9,6 +9,12 @@ from keras.src.backend.tensorflow.core import convert_to_tensor
 
 def segment_sum(data, segment_ids, num_segments=None, sorted=False):
     if sorted:
+        if num_segments is not None:
+            raise ValueError(
+                "Argument `num_segments` cannot be set when sorted is True "
+                "when using the tensorflow backend."
+                f"Received: num_segments={num_segments}, sorted={sorted}."
+            )
         return tf.math.segment_sum(data, segment_ids)
     else:
         if num_segments is None:
@@ -19,6 +25,12 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
 
 def segment_max(data, segment_ids, num_segments=None, sorted=False):
     if sorted:
+        if num_segments is not None:
+            raise ValueError(
+                "Argument `num_segments` cannot be set when sorted is True "
+                "when using the tensorflow backend."
+                f"Received: num_segments={num_segments}, sorted={sorted}."
+            )
         return tf.math.segment_max(data, segment_ids)
     else:
         if num_segments is None:

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1800,22 +1800,6 @@ def roll(x, shift, axis=None):
     return tf.reshape(x, original_shape)
 
 
-def searchsorted(sorted_sequence, values, side="left"):
-    if ndim(sorted_sequence) != 1:
-        raise ValueError(
-            "`searchsorted` only supports 1-D sorted sequences. "
-            "You can use `keras.ops.vectorized_map` "
-            "to extend it to N-D sequences. Received: "
-            f"sorted_sequence.shape={sorted_sequence.shape}"
-        )
-    out_type = (
-        "int32" if len(sorted_sequence) <= np.iinfo(np.int32).max else "int64"
-    )
-    return tf.searchsorted(
-        sorted_sequence, values, side=side, out_type=out_type
-    )
-
-
 @sparse.elementwise_unary
 def sign(x):
     x = convert_to_tensor(x)

--- a/keras/src/backend/tensorflow/trainer.py
+++ b/keras/src/backend/tensorflow/trainer.py
@@ -638,7 +638,6 @@ class TFEpochIterator(EpochIterator):
         return self.data_adapter.get_tf_dataset()
 
     def enumerate_epoch(self):
-        self.data_adapter.on_epoch_begin()
         if self.steps_per_epoch:
             if not self._current_iterator:
                 self._current_iterator = iter(self._distributed_dataset)

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -15,8 +15,6 @@ from keras.src.backend.common.backend_utils import slice_along_axis
 from keras.src.backend.common.dtypes import result_type
 from keras.src.backend.common.keras_tensor import KerasTensor
 from keras.src.backend.common.stateless_scope import StatelessScope
-from keras.src.backend.common.stateless_scope import get_stateless_scope
-from keras.src.backend.common.stateless_scope import in_stateless_scope
 from keras.src.backend.config import floatx
 
 SUPPORTS_SPARSE_TENSORS = False
@@ -131,38 +129,15 @@ class Variable(KerasVariable):
 
     @property
     def value(self):
-        # We cannot chain super() here because it will fail TorchDynamo. The
-        # reason why is unclear.
-        def maybe_use_symbolic_tensor(value):
-            # Create and use a symbolic tensor stub in symbolic calls.
-            if str(get_device()) == "meta" and str(value.device) != "meta":
-                return torch.nn.Parameter(
-                    torch.empty(
-                        size=self._shape,
-                        dtype=to_torch_dtype(self._dtype),
-                        device="meta",
-                    ),
-                    requires_grad=self.trainable,
-                )
-            return value
-
-        if in_stateless_scope():
-            scope = get_stateless_scope()
-            value = scope.get_current_value(self)
-            if value is not None:
-                value = self._maybe_autocast(value)
-                return maybe_use_symbolic_tensor(value)
-        if self._value is None:
-            # Uninitialized variable. Return a placeholder.
-            # This is fine because it's only ever used
-            # in during shape inference / graph tracing
-            # (anything else would be a bug, to be fixed.)
-            value = self._maybe_autocast(
-                self._initializer(self._shape, dtype=self._dtype)
+        value = super().value
+        # Create and use a symbolic tensor stub in symbolic calls.
+        if str(get_device()) == "meta" and str(value.device) != "meta":
+            return torch.empty(
+                size=value.shape,
+                dtype=value.dtype,
+                device="meta",
             )
-        else:
-            value = self._maybe_autocast(self._value)
-        return maybe_use_symbolic_tensor(value)
+        return value
 
     @property
     def trainable(self):
@@ -184,15 +159,6 @@ class Variable(KerasVariable):
 def convert_to_tensor(x, dtype=None, sparse=None):
     if sparse:
         raise ValueError("`sparse=True` is not supported with torch backend")
-    if type(x) is Variable:
-        # We cannot use `isinstance(x, Variable)` due to the failure of
-        # TorchDynamo.
-        # torch._dynamo.exc.InternalTorchDynamoError:
-        # GetAttrVariable(SuperVariable(), value) has no type.
-        # TorchDynamo has bugs supporting nn.Parameter type check.
-        # Return it directly instead of pass it to the rest of the logic in the
-        # function.
-        return x.value
     if is_tensor(x):
         device = get_device()
         if x.device != device:
@@ -200,6 +166,11 @@ def convert_to_tensor(x, dtype=None, sparse=None):
         if dtype is None:
             return x
         return x.to(to_torch_dtype(dtype))
+    if isinstance(x, Variable):
+        # TorchDynamo has bugs supporting nn.Parameter type check.
+        # Return it directly instead of pass it to the rest of the logic in the
+        # function.
+        return x.value
     if dtype is None:
         if isinstance(x, bool):
             return torch.as_tensor(x, dtype=torch.bool, device=get_device())

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -1,7 +1,6 @@
 import builtins
 import math
 
-import numpy as np
 import torch
 
 from keras.src.backend import KerasTensor
@@ -1193,20 +1192,6 @@ def reshape(x, newshape):
 def roll(x, shift, axis=None):
     x = convert_to_tensor(x)
     return torch.roll(x, shift, dims=axis)
-
-
-def searchsorted(sorted_sequence, values, side="left"):
-    if ndim(sorted_sequence) != 1:
-        raise ValueError(
-            "`searchsorted` only supports 1-D sorted sequences. "
-            "You can use `keras.ops.vectorized_map` "
-            "to extend it to N-D sequences. Received: "
-            f"sorted_sequence.shape={sorted_sequence.shape}"
-        )
-    out_int32 = len(sorted_sequence) <= np.iinfo(np.int32).max
-    return torch.searchsorted(
-        sorted_sequence, values, side=side, out_int32=out_int32
-    )
 
 
 def sign(x):

--- a/keras/src/distribution/distribution_lib.py
+++ b/keras/src/distribution/distribution_lib.py
@@ -98,7 +98,7 @@ def initialize(job_addresses=None, num_processes=None, process_id=None):
         ```python
         os.environ[
             "KERAS_DISTRIBUTION_JOB_ADDRESSES"] = "10.0.0.1:1234,10.0.0.2:2345"
-        os.environ["KERAS_DISTRIBUTION_NUM_PROCESSES"] = "2"
+        os.environ["KERAS_DISTRIBUTION_NUM_PROCESSES"] = "2
         os.environ["KERAS_DISTRIBUTION_PROCESS_ID"] = "0"
         keras.distribute.initialize()
         ```
@@ -107,7 +107,7 @@ def initialize(job_addresses=None, num_processes=None, process_id=None):
         ```python
         os.environ[
             "KERAS_DISTRIBUTION_JOB_ADDRESSES"] = "10.0.0.1:1234,10.0.0.2:2345"
-        os.environ["KERAS_DISTRIBUTION_NUM_PROCESSES"] = "2"
+        os.environ["KERAS_DISTRIBUTION_NUM_PROCESSES"] = "2
         os.environ["KERAS_DISTRIBUTION_PROCESS_ID"] = "1"
         keras.distribute.initialize()
         ```

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -524,12 +524,15 @@ class Dense(Layer):
             x = self.activation(x)
         return x
 
-    def quantize(self, mode, type_check=True):
+    def quantize(self, mode):
         import gc
 
         # Prevent quantization of the subclasses
-        if type_check and (type(self) is not Dense):
-            raise self._quantize_not_implemented_error()
+        if type(self) is not Dense:
+            raise NotImplementedError(
+                f"Layer {self.__class__.__name__} does not have a `quantize()` "
+                "method implemented."
+            )
         self._check_quantize_args(mode, self.compute_dtype)
 
         self._tracker.unlock()

--- a/keras/src/layers/core/dense_test.py
+++ b/keras/src/layers/core/dense_test.py
@@ -408,8 +408,6 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
         with self.assertRaises(NotImplementedError):
             layer.quantize(mode)
 
-        layer.quantize(mode, type_check=False)  # No error
-
     @parameterized.named_parameters(
         ("int8", "int8"),
         ("float8", "float8"),
@@ -424,7 +422,12 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
             ):
                 layer.quantize(m)
 
-        layer = layers.Dense(units=2, dtype=f"{mode}_from_float32")
+    @parameterized.named_parameters(
+        ("int8", "int8_from_float32"),
+        ("float8", "float8_from_float32"),
+    )
+    def test_quantize_when_already_quantized_using_dtype_argument(self, mode):
+        layer = layers.Dense(units=2, dtype=mode)
         layer.build((None, 2))
         for m in ["int8", "float8"]:
             with self.assertRaisesRegex(
@@ -476,21 +479,18 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
             layer.quantized_call(x)
         self.assertEqual(layer.dtype_policy, original_dtype_policy)
 
-    @parameterized.named_parameters(
-        ("int8", "int8_from_mixed_bfloat16", 1, 2),
-        ("float8", "float8_from_mixed_bfloat16", 8, 0),
-    )
     @pytest.mark.requires_trainable_backend
-    def test_quantize_dtype_argument(
-        self, dtype, num_trainable_weights, num_non_trainable_weights
-    ):
+    def test_quantize_int8_dtype_argument(self):
         self.run_layer_test(
             layers.Dense,
-            init_kwargs={"units": 5, "dtype": dtype},
+            init_kwargs={
+                "units": 5,
+                "dtype": "int8_from_mixed_bfloat16",
+            },
             input_shape=(2, 3, 4),
             expected_output_shape=(2, 3, 5),
-            expected_num_trainable_weights=num_trainable_weights,
-            expected_num_non_trainable_weights=num_non_trainable_weights,
+            expected_num_trainable_weights=1,
+            expected_num_non_trainable_weights=2,
             expected_num_seed_generators=0,
             expected_num_losses=0,
             supports_masking=True,
@@ -576,6 +576,23 @@ class DenseTest(testing.TestCase, parameterized.TestCase):
                 reloaded_layer.non_trainable_weights,
                 len(model.non_trainable_weights),
             )
+
+    @pytest.mark.requires_trainable_backend
+    def test_quantize_float8_dtype_argument(self):
+        self.run_layer_test(
+            layers.Dense,
+            init_kwargs={
+                "units": 5,
+                "dtype": "float8_from_mixed_bfloat16",
+            },
+            input_shape=(2, 3, 4),
+            expected_output_shape=(2, 3, 5),
+            expected_num_trainable_weights=8,
+            expected_num_non_trainable_weights=0,
+            expected_num_seed_generators=0,
+            expected_num_losses=0,
+            supports_masking=True,
+        )
 
     @pytest.mark.requires_trainable_backend
     def test_quantize_float8(self):

--- a/keras/src/layers/core/einsum_dense.py
+++ b/keras/src/layers/core/einsum_dense.py
@@ -640,12 +640,15 @@ class EinsumDense(Layer):
             x = self.activation(x)
         return x
 
-    def quantize(self, mode, type_check=True):
+    def quantize(self, mode):
         import gc
 
         # Prevent quantization of the subclasses
-        if type_check and (type(self) is not EinsumDense):
-            raise self._quantize_not_implemented_error()
+        if type(self) is not EinsumDense:
+            raise NotImplementedError(
+                f"Layer {self.__class__.__name__} does not have a `quantize()` "
+                "method implemented."
+            )
         self._check_quantize_args(mode, self.compute_dtype)
 
         self._tracker.unlock()

--- a/keras/src/layers/core/einsum_dense_test.py
+++ b/keras/src/layers/core/einsum_dense_test.py
@@ -515,8 +515,6 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
         with self.assertRaises(NotImplementedError):
             layer.quantize(mode)
 
-        layer.quantize(mode, type_check=False)  # No error
-
     @parameterized.named_parameters(
         ("int8", "int8"),
         ("float8", "float8"),
@@ -535,11 +533,16 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
             ):
                 layer.quantize(m)
 
+    @parameterized.named_parameters(
+        ("int8", "int8_from_float32"),
+        ("float8", "float8_from_float32"),
+    )
+    def test_quantize_when_already_quantized_using_dtype_argument(self, mode):
         layer = layers.EinsumDense(
             equation="ab,bcd->acd",
             output_shape=(8, 16),
             bias_axes="d",
-            dtype=f"{mode}_from_float32",
+            dtype=mode,
         )
         layer.build((None, 3))
         for m in ["int8", "float8"]:
@@ -600,26 +603,20 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
             layer.quantized_call(x)
         self.assertEqual(layer.dtype_policy, original_dtype_policy)
 
-    @parameterized.named_parameters(
-        ("int8", "int8_from_mixed_bfloat16", 1, 2),
-        ("float8", "float8_from_mixed_bfloat16", 8, 0),
-    )
     @pytest.mark.requires_trainable_backend
-    def test_quantize_dtype_argument(
-        self, dtype, num_trainable_weights, num_non_trainable_weights
-    ):
+    def test_quantize_int8_dtype_argument(self):
         self.run_layer_test(
             layers.EinsumDense,
             init_kwargs={
                 "equation": "ab,bcd->acd",
                 "output_shape": (8, 32),
                 "bias_axes": "d",
-                "dtype": dtype,
+                "dtype": "int8_from_mixed_bfloat16",
             },
             input_shape=(2, 3),
             expected_output_shape=(2, 8, 32),
-            expected_num_trainable_weights=num_trainable_weights,
-            expected_num_non_trainable_weights=num_non_trainable_weights,
+            expected_num_trainable_weights=1,
+            expected_num_non_trainable_weights=2,
             expected_num_seed_generators=0,
             expected_num_losses=0,
             supports_masking=False,
@@ -707,6 +704,25 @@ class EinsumDenseTest(testing.TestCase, parameterized.TestCase):
                 reloaded_layer.non_trainable_weights,
                 len(model.non_trainable_weights),
             )
+
+    @pytest.mark.requires_trainable_backend
+    def test_quantize_float8_dtype_argument(self):
+        self.run_layer_test(
+            layers.EinsumDense,
+            init_kwargs={
+                "equation": "ab,bcd->acd",
+                "output_shape": (8, 32),
+                "bias_axes": "d",
+                "dtype": "float8_from_mixed_bfloat16",
+            },
+            input_shape=(2, 3),
+            expected_output_shape=(2, 8, 32),
+            expected_num_trainable_weights=8,
+            expected_num_non_trainable_weights=0,
+            expected_num_seed_generators=0,
+            expected_num_losses=0,
+            supports_masking=False,
+        )
 
     @pytest.mark.requires_trainable_backend
     def test_quantize_float8(self):

--- a/keras/src/layers/core/embedding.py
+++ b/keras/src/layers/core/embedding.py
@@ -344,12 +344,15 @@ class Embedding(Layer):
             outputs = ops.add(outputs, lora_outputs)
         return outputs
 
-    def quantize(self, mode, type_check=True):
+    def quantize(self, mode):
         import gc
 
         # Prevent quantization of the subclasses
-        if type_check and (type(self) is not Embedding):
-            raise self._quantize_not_implemented_error()
+        if type(self) is not Embedding:
+            raise NotImplementedError(
+                f"Layer {self.__class__.__name__} does not have a `quantize()` "
+                "method implemented."
+            )
         self._check_quantize_args(mode, self.compute_dtype)
 
         self._tracker.unlock()

--- a/keras/src/layers/core/embedding_test.py
+++ b/keras/src/layers/core/embedding_test.py
@@ -308,11 +308,8 @@ class EmbeddingTest(test_case.TestCase, parameterized.TestCase):
             pass
 
         layer = MyEmbedding(10, 16)
-        layer.build()
         with self.assertRaises(NotImplementedError):
             layer.quantize("int8")
-
-        layer.quantize("int8", type_check=False)  # No error
 
     def test_quantize_when_already_quantized(self):
         layer = layers.Embedding(10, 16)
@@ -323,6 +320,7 @@ class EmbeddingTest(test_case.TestCase, parameterized.TestCase):
         ):
             layer.quantize("int8")
 
+    def test_quantize_when_already_quantized_using_dtype_argument(self):
         layer = layers.Embedding(10, 16, dtype="int8_from_float32")
         layer.build()
         with self.assertRaisesRegex(

--- a/keras/src/layers/layer.py
+++ b/keras/src/layers/layer.py
@@ -1171,10 +1171,7 @@ class Layer(BackendLayer, Operation, KerasSaveable):
             layer._clear_losses()
 
     def quantize(self, mode):
-        raise self._quantize_not_implemented_error()
-
-    def _quantize_not_implemented_error(self):
-        return NotImplementedError(
+        raise NotImplementedError(
             f"Layer {self.__class__.__name__} does not have a `quantize()` "
             "method implemented."
         )

--- a/keras/src/models/functional.py
+++ b/keras/src/models/functional.py
@@ -536,10 +536,6 @@ def functional_from_config(cls, config, custom_objects=None):
 
     input_tensors = map_tensors(config["input_layers"])
     output_tensors = map_tensors(config["output_layers"])
-    if isinstance(input_tensors, list) and len(input_tensors) == 1:
-        input_tensors = input_tensors[0]
-    if isinstance(output_tensors, list) and len(output_tensors) == 1:
-        output_tensors = output_tensors[0]
 
     return cls(
         inputs=input_tensors,

--- a/keras/src/models/functional_test.py
+++ b/keras/src/models/functional_test.py
@@ -4,7 +4,6 @@ import warnings
 import numpy as np
 import pytest
 
-from keras.src import applications
 from keras.src import backend
 from keras.src import layers
 from keras.src import saving
@@ -13,7 +12,6 @@ from keras.src.layers.core.input_layer import Input
 from keras.src.layers.input_spec import InputSpec
 from keras.src.models import Functional
 from keras.src.models import Model
-from keras.src.models import Sequential
 
 
 class FunctionalTest(testing.TestCase):
@@ -467,23 +465,6 @@ class FunctionalTest(testing.TestCase):
         out = model([np.ones((2, 2)), None])
         self.assertAllClose(out, np.ones((2, 2)))
         # Note: it's not intended to work in symbolic mode (yet).
-
-    def test_for_functional_in_sequential(self):
-        # Test for a v3.4.1 regression.
-        if backend.image_data_format() == "channels_first":
-            image_size = (3, 100, 100)
-        else:
-            image_size = (100, 100, 3)
-        base_model = applications.mobilenet.MobileNet(
-            include_top=False, weights=None
-        )
-        model = Sequential()
-        model.add(layers.Input(shape=image_size))
-        model.add(base_model)
-        model.add(layers.GlobalAveragePooling2D())
-        model.add(layers.Dense(7, activation="softmax"))
-        config = model.get_config()
-        model = Sequential.from_config(config)
 
     def test_add_loss(self):
         # TODO

--- a/keras/src/ops/math.py
+++ b/keras/src/ops/math.py
@@ -8,18 +8,44 @@ from keras.src.ops.operation import Operation
 from keras.src.ops.operation_utils import reduce_shape
 
 
-class SegmentSum(Operation):
+def _segment_reduce_validation(data, segment_ids):
+    data_shape = data.shape
+    segment_ids_shape = segment_ids.shape
+    if len(segment_ids_shape) > 1:
+        raise ValueError(
+            "Argument `segment_ids` should be an 1-D vector, got shape: "
+            f"{len(segment_ids_shape)}. Consider either flatten input with "
+            "segment_ids.reshape((-1)) and "
+            "data.reshape((-1, ) + data.shape[len(segment_ids.shape):]) or "
+            "vectorize with vmap."
+        )
+    if (
+        segment_ids_shape[0] is not None
+        and data_shape[0] is not None
+        and segment_ids_shape[0] != data_shape[0]
+    ):
+        raise ValueError(
+            "Argument `segment_ids` and `data` should have same leading "
+            f"dimension. Got {segment_ids_shape} v.s. "
+            f"{data_shape}."
+        )
+
+
+class SegmentReduction(Operation):
     def __init__(self, num_segments=None, sorted=False):
         super().__init__()
         self.num_segments = num_segments
         self.sorted = sorted
 
-    def compute_output_spec(self, data, segment_ids):
-        num_segments = self.num_segments
-        output_shape = (num_segments,) + tuple(data.shape[1:])
+    def compute_output_spec(self, data, _):
+        output_shape = (self.num_segments,) + tuple(data.shape[1:])
         return KerasTensor(shape=output_shape, dtype=data.dtype)
 
+
+class SegmentSum(SegmentReduction):
+
     def call(self, data, segment_ids):
+        _segment_reduce_validation(data, segment_ids)
         return backend.math.segment_sum(
             data,
             segment_ids,
@@ -34,8 +60,9 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
 
     Args:
         data: Input tensor.
-        segment_ids: A 1-D tensor containing segment indices for each
-            element in `data`.
+        segment_ids: A N-D tensor containing segment indices for each
+            element in `data`. Num dims for segment ids should be strictly
+            smaller or equal to number of dims in data.
         num_segments: An integer representing the total number of
             segments. If not specified, it is inferred from the maximum
             value in `segment_ids`.
@@ -54,6 +81,7 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
     >>> keras.ops.segment_sum(data, segment_ids,num_segments)
     array([3, 30, 300], dtype=int32)
     """
+    _segment_reduce_validation(data, segment_ids)
     if any_symbolic_tensors((data,)):
         return SegmentSum(num_segments, sorted).symbolic_call(data, segment_ids)
     return backend.math.segment_sum(
@@ -61,18 +89,10 @@ def segment_sum(data, segment_ids, num_segments=None, sorted=False):
     )
 
 
-class SegmentMax(Operation):
-    def __init__(self, num_segments=None, sorted=False):
-        super().__init__()
-        self.num_segments = num_segments
-        self.sorted = sorted
-
-    def compute_output_spec(self, data, segment_ids):
-        num_segments = self.num_segments
-        output_shape = (num_segments,) + tuple(data.shape[1:])
-        return KerasTensor(shape=output_shape, dtype=data.dtype)
+class SegmentMax(SegmentReduction):
 
     def call(self, data, segment_ids):
+        _segment_reduce_validation(data, segment_ids)
         return backend.math.segment_max(
             data,
             segment_ids,
@@ -87,8 +107,8 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
 
     Args:
         data: Input tensor.
-        segment_ids: A 1-D tensor containing segment indices for each
-            element in `data`.
+        segment_ids: A N-D tensor containing segment indices for each
+            element in `data`. data.shape[:len(segment_ids.shape)] should match.
         num_segments: An integer representing the total number of
             segments. If not specified, it is inferred from the maximum
             value in `segment_ids`.
@@ -107,6 +127,7 @@ def segment_max(data, segment_ids, num_segments=None, sorted=False):
     >>> keras.ops.segment_max(data, segment_ids, num_segments)
     array([2, 20, 200], dtype=int32)
     """
+    _segment_reduce_validation(data, segment_ids)
     if any_symbolic_tensors((data,)):
         return SegmentMax(num_segments, sorted).symbolic_call(data, segment_ids)
     return backend.math.segment_max(

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -4503,49 +4503,6 @@ def round(x, decimals=0):
     return backend.numpy.round(x, decimals)
 
 
-class SearchSorted(Operation):
-    def call(self, sorted_sequence, values, side="left"):
-        sorted_sequence = backend.convert_to_tensor(sorted_sequence)
-        values = backend.convert_to_tensor(values)
-        return backend.numpy.searchsorted(sorted_sequence, values, side=side)
-
-    def compute_output_spec(self, sorted_sequence, values, side="left"):
-        if len(sorted_sequence.shape) != 1:
-            raise ValueError(
-                "searchsorted only supports 1-D sorted sequences. Use"
-                "keras.ops.vectorized_map to extend to N-D sequences."
-            )
-        out_type = (
-            "int32"
-            if sorted_sequence.shape[0] <= np.iinfo(np.int32).max
-            else "int64"
-        )
-        return KerasTensor(values.shape, dtype=out_type)
-
-
-@keras_export(["keras.ops.searchsorted"])
-def searchsorted(sorted_sequence, values, side="left"):
-    """Perform a binary search, returning indices for insertion of `values`
-    into `sorted_sequence` that maintain the sorting order.
-
-    Args:
-        sorted_sequence: 1-D input tensor, sorted along the innermost
-            dimension.
-        values: N-D tensor of query insertion values.
-        side: 'left' or 'right', specifying the direction in which to insert
-            for the equality case (tie-breaker).
-
-    Returns:
-        Tensor of insertion indices of same shape as `values`.
-    """
-    if any_symbolic_tensors((sorted_sequence, values)):
-        return SearchSorted().symbolic_call(sorted_sequence, values, side=side)
-
-    sorted_sequence = backend.convert_to_tensor(sorted_sequence)
-    values = backend.convert_to_tensor(values)
-    return backend.numpy.searchsorted(sorted_sequence, values, side=side)
-
-
 class Sign(Operation):
     def call(self, x):
         return backend.numpy.sign(x)

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -775,12 +775,6 @@ class NumpyTwoInputOpsStaticShapeTest(testing.TestCase):
             (2, 3, 1),
         )
 
-    def test_searchsorted(self):
-        a = KerasTensor((3,))
-        v = KerasTensor((2, 3))
-
-        self.assertEqual(knp.searchsorted(a, v).shape, v.shape)
-
     def test_take(self):
         x = KerasTensor((2, 3))
         self.assertEqual(knp.take(x, 1).shape, ())
@@ -3972,13 +3966,6 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase, parameterized.TestCase):
         x = np.array([[123, 234, 345], [345, 234, 123]], dtype="int32")
         self.assertAllClose(knp.round(x, decimals=-1), np.round(x, decimals=-1))
         self.assertAllClose(knp.Round(decimals=-1)(x), np.round(x, decimals=-1))
-
-    def test_searchsorted(self):
-        a = np.array([1, 2, 2, 3, 4, 5, 5])
-        v = np.array([4, 3, 5, 1, 2])
-        expected = np.searchsorted(a, v).astype("int32")
-        self.assertAllEqual(knp.searchsorted(a, v), expected)
-        self.assertAllEqual(knp.SearchSorted()(a, v), expected)
 
     def test_sign(self):
         x = np.array([[1, -2, 3], [-3, 2, -1]])
@@ -7374,30 +7361,6 @@ class NumpyDtypeTest(testing.TestCase, parameterized.TestCase):
         )
         self.assertEqual(
             standardize_dtype(knp.Quantile().symbolic_call(x, 0.5).dtype),
-            expected_dtype,
-        )
-
-    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
-    def test_searchsorted(self, dtype):
-        import jax.numpy as jnp
-
-        if dtype == "bool":
-            self.skipTest("searchsorted doesn't support bool dtype")
-
-        a = knp.ones((3,), dtype=dtype)
-        v = knp.ones((3,), dtype=dtype)
-
-        a_jax = jnp.ones((3,), dtype=dtype)
-        v_jax = jnp.ones((3,), dtype=dtype)
-
-        expected_dtype = standardize_dtype(jnp.searchsorted(a_jax, v_jax).dtype)
-
-        self.assertEqual(
-            standardize_dtype(knp.searchsorted(a, v).dtype), expected_dtype
-        )
-
-        self.assertEqual(
-            standardize_dtype(knp.SearchSorted().symbolic_call(a, v).dtype),
             expected_dtype,
         )
 

--- a/keras/src/random/seed_generator.py
+++ b/keras/src/random/seed_generator.py
@@ -88,7 +88,7 @@ class SeedGenerator:
             increment = self.backend.convert_to_tensor(
                 np.array([0, 1]), dtype=seed_state.dtype
             )
-            self.state.assign(self.backend.numpy.add(seed_state, increment))
+            self.state.assign(seed_state + increment)
         else:
             # This produces a sequence of near-unique numbers
             # between 0 and 1M

--- a/keras/src/trainers/data_adapters/data_adapter.py
+++ b/keras/src/trainers/data_adapters/data_adapter.py
@@ -87,10 +87,6 @@ class DataAdapter:
         """
         raise NotImplementedError
 
-    def on_epoch_begin(self):
-        """A hook called before each epoch."""
-        pass
-
     def on_epoch_end(self):
         """A hook called after each epoch."""
         pass

--- a/keras/src/trainers/data_adapters/py_dataset_adapter.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter.py
@@ -21,8 +21,7 @@ class PyDataset:
 
     Every `PyDataset` must implement the `__getitem__()` and the `__len__()`
     methods. If you want to modify your dataset between epochs,
-    you may additionally implement `on_epoch_end()`,
-    or `on_epoch_begin` to be called at the start of each epoch.
+    you may additionally implement `on_epoch_end()`.
     The `__getitem__()` method should return a complete batch
     (not a single sample), and the `__len__` method should return
     the number of batches in the dataset (rather than the number of samples).
@@ -171,10 +170,6 @@ class PyDataset:
             "@property\ndef num_batches(self):\n  return ..."
         )
 
-    def on_epoch_begin(self):
-        """Method called at the beginning of every epoch."""
-        pass
-
     def on_epoch_end(self):
         """Method called at the end of every epoch."""
         pass
@@ -303,9 +298,6 @@ class PyDatasetAdapter(DataAdapter):
 
     def get_torch_dataloader(self):
         return data_adapter_utils.get_torch_dataloader(self._get_iterator())
-
-    def on_epoch_begin(self):
-        self.py_dataset.on_epoch_begin()
 
     def on_epoch_end(self):
         if self.enqueuer:
@@ -566,11 +558,8 @@ class OrderedEnqueuer(PyDatasetEnqueuer):
                         # We're done
                         return
 
-                # Call the internal on epoch end and epoch begin.
+                # Call the internal on epoch end.
                 self.py_dataset.on_epoch_end()
-                # The first on_epoch_begin call was already made,
-                # prior to the start of the Enqueuer.
-                self.py_dataset.on_epoch_begin()
                 self._send_py_dataset()  # Update the pool
         except Exception as e:
             self.queue.put(e)  # Report exception

--- a/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
+++ b/keras/src/trainers/data_adapters/py_dataset_adapter_test.py
@@ -144,8 +144,6 @@ class PyDatasetAdapterTest(testing.TestCase, parameterized.TestCase):
     ):
         if use_multiprocessing and (infinite or shuffle):
             pytest.skip("Starting processes is slow, only test one variant")
-        if testing.tensorflow_uses_gpu():
-            pytest.skip("This test is flaky with TF on GPU")
 
         set_random_seed(1337)
         x = np.random.random((64, 4)).astype("float32")

--- a/keras/src/trainers/epoch_iterator.py
+++ b/keras/src/trainers/epoch_iterator.py
@@ -77,7 +77,6 @@ class EpochIterator:
 
     def enumerate_epoch(self):
         buffer = []
-        self.data_adapter.on_epoch_begin()
         if self.steps_per_epoch:
             if self._current_iterator is None:
                 self._current_iterator = iter(self._get_iterator())

--- a/keras/src/trainers/epoch_iterator_test.py
+++ b/keras/src/trainers/epoch_iterator_test.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 import tensorflow as tf
-from absl.testing import parameterized
 
 from keras.src import backend
 from keras.src import testing
@@ -9,7 +8,7 @@ from keras.src.trainers import data_adapters
 from keras.src.trainers import epoch_iterator
 
 
-class TestEpochIterator(testing.TestCase, parameterized.TestCase):
+class TestEpochIterator(testing.TestCase):
     def test_basic_flow(self):
         x = np.random.random((100, 16))
         y = np.random.random((100, 4))
@@ -172,54 +171,3 @@ class TestEpochIterator(testing.TestCase, parameterized.TestCase):
         x = "unsupported_data"
         with self.assertRaisesRegex(ValueError, "Unrecognized data type"):
             _ = epoch_iterator.EpochIterator(x=x)
-
-    @parameterized.named_parameters(
-        [
-            {"testcase_name": "infinite", "infinite": True},
-            {"testcase_name": "finite", "infinite": False},
-        ]
-    )
-    def test_epoch_callbacks(self, infinite):
-        class TestPyDataset(data_adapters.py_dataset_adapter.PyDataset):
-            def __init__(
-                self,
-                workers=1,
-                use_multiprocessing=False,
-                max_queue_size=10,
-                infinite=False,
-            ):
-                super().__init__(workers, use_multiprocessing, max_queue_size)
-                self.data = np.random.rand(64, 2)
-                self.batch_size = 16
-                self.infinite = infinite
-
-                # check that callbacks are called in the correct order
-                self.tracker = []
-
-            @property
-            def num_batches(self):
-                if self.infinite:
-                    return None
-                return len(self.data) // self.batch_size
-
-            def on_epoch_begin(self):
-                self.tracker.append(1)
-
-            def __getitem__(self, index):
-                idx = index % 2
-                return self.data[
-                    idx * self.batch_size : (idx + 1) * self.batch_size
-                ]
-
-            def on_epoch_end(self):
-                self.tracker.append(2)
-
-        ds = TestPyDataset(infinite=infinite)
-        epoch_iter = epoch_iterator.EpochIterator(x=ds, steps_per_epoch=10)
-
-        num_epochs = 5
-        for epoch in range(num_epochs):
-            for step, batch in epoch_iter.enumerate_epoch():
-                pass
-
-        self.assertAllEqual(ds.tracker, [1, 2] * num_epochs)

--- a/requirements-jax-cuda.txt
+++ b/requirements-jax-cuda.txt
@@ -1,9 +1,9 @@
 # Tensorflow cpu-only version (needed for testing).
-tensorflow-cpu~=2.16.2  # Pin to TF 2.16
+tensorflow-cpu~=2.16.1  # Pin to TF 2.16
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0
+torch>=2.1.0, <2.3.0
 torchvision>=0.16.0
 
 # Jax with cuda support.

--- a/requirements-tensorflow-cuda.txt
+++ b/requirements-tensorflow-cuda.txt
@@ -1,9 +1,9 @@
 # Tensorflow with cuda support.
-tensorflow[and-cuda]~=2.16.2  # Pin to TF 2.16
+tensorflow[and-cuda]~=2.16.1  # Pin to TF 2.16
 
 # Torch cpu-only version (needed for testing).
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0
+torch>=2.1.0, <2.3.0
 torchvision>=0.16.0
 
 # Jax cpu-only version (needed for testing).

--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,10 +1,10 @@
 # Tensorflow cpu-only version (needed for testing).
-tensorflow-cpu~=2.16.2  # Pin to TF 2.16
+tensorflow-cpu~=2.16.1  # Pin to TF 2.16
 
 # Torch with cuda support.
 --extra-index-url https://download.pytorch.org/whl/cu121
-torch==2.3.1+cu121
-torchvision==0.18.1+cu121
+torch==2.2.1+cu121
+torchvision==0.17.1+cu121
 
 # Jax cpu-only version (needed for testing).
 jax[cpu]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # Tensorflow.
-tensorflow-cpu~=2.16.2;sys_platform != 'darwin'  # Pin to TF 2.16
-tensorflow~=2.16.2;sys_platform == 'darwin'
+tensorflow-cpu~=2.16.1;sys_platform != 'darwin'  # Pin to TF 2.16
+tensorflow~=2.16.1;sys_platform == 'darwin'
 
 # Torch.
 # TODO: Pin to < 2.3.0 (GitHub issue #19602)
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch>=2.1.0
+torch>=2.1.0, <2.3.0
 torchvision>=0.16.0
 
 # Jax.


### PR DESCRIPTION
Recreated from original PR: https://github.com/keras-team/keras/pull/19963

`tf.unsorted_segment_*` is actually able to handle n dimension segment_ids but all other backends and `tf.segment_*` doesn't support this case. this pr adds an actual validation check to let user know about the requirements.

in addition to above, i also:
1. reduced boilerplate code in numpy and torch implementation
2. fixed numpy and torch's segment_max initialization state handling issue
3. reduced boilerplate code for segment reduction in unit tests and test for more cases.